### PR TITLE
Passwords are hashed with unique per user salt.

### DIFF
--- a/Client/Pages/Signup.razor
+++ b/Client/Pages/Signup.razor
@@ -50,6 +50,7 @@
         // If success, create user in DB and navigate to index page (force reload).
               
         var response = await Http.PostAsJsonAsync("api/Users", user);
+
         if (response.IsSuccessStatusCode)
         {
 

--- a/Server/Services/UsersService.cs
+++ b/Server/Services/UsersService.cs
@@ -29,6 +29,10 @@ public class UsersService
 
     public async Task<User?> GetUsernameAsync(string username) =>
         await _usersCollection.Find(x => x.UserName == username).FirstOrDefaultAsync();
+    
+    public async Task<string> GetSalt(string username) =>
+        (await _usersCollection.Find(x => x.UserName == username).FirstOrDefaultAsync()).PasswordSalt!;
+    
     public async Task<User?> Signin(string username, string password) =>
         await _usersCollection.Find(x => x.UserName == username && x.Password == password).FirstOrDefaultAsync();
     public async Task CreateAsync(User newUser) =>

--- a/Shared/Models/User.cs
+++ b/Shared/Models/User.cs
@@ -13,6 +13,7 @@ public class User
     [BsonElement("Name")]
     public string UserName { get; set; } = null!;
     public string Password { get; set; } = null!;
+    public string? PasswordSalt { get; set; } // For ID and Password salt we should get rid of th nullable property by using DTOs
     [EmailAddress]
     public string Email { get; set; } = null!;
 


### PR DESCRIPTION
Added password hashing using Rfc2898DeriveBytes Class System.Security.Cryptography

Users' passwords are additionally encrypted by appending a randomly generated salt, which is stored in plain text in the database along with the encrypted password. This ensures common passwords like 1234 can't simply be looked up in a hash dictionary

You might have to clear existing users for this to work.